### PR TITLE
Update the fibonacci examples (and ignore libcfslib.so)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 lib/libcryptolib.so
 lib/libcryptolib.wasm
+lib/libcfslib.so
 bin
 coverage.txt
 *.sw*

--- a/docs/GoTutorial.md
+++ b/docs/GoTutorial.md
@@ -8,7 +8,6 @@ colonies dev
 ## 2. Environmental variables
 ```console
 source examples/devenv
-}
 ```
 
 ## 3. Fibonacci Job Generator code (examples/generator/generator.go)

--- a/docs/GoTutorial.md
+++ b/docs/GoTutorial.md
@@ -11,77 +11,77 @@ source examples/devenv
 }
 ```
 
-## 3. Fibonacci Job Generator code (examples/generator.go)
+## 3. Fibonacci Job Generator code (examples/generator/generator.go)
 ```go
 func main() {
-    colonyID := os.Getenv("COLONIES_COLONY_ID")
-    executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
-    coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
-    coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
-    coloniesPort, err := strconv.Atoi(coloniesPortStr)
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(-1)
-    }
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
+	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
+	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
+	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
+	coloniesPort, err := strconv.Atoi(coloniesPortStr)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 
-    funcSpec := core.CreateEmptyFunctionSpec()
-    funcSpec.Conditions.ColonyName = colonyID
-    funcSpec.Conditions.ExecutorType = os.Getenv("COLONIES_EXECUTOR_TYPE")
-    funcSpec.Env["fibonacciNum"] = os.Args[1]
+	funcSpec := core.CreateEmptyFunctionSpec()
+	funcSpec.Conditions.ColonyName = colonyName
+	funcSpec.Conditions.ExecutorType = os.Getenv("COLONIES_EXECUTOR_TYPE")
+	funcSpec.Env["fibonacciNum"] = os.Args[1]
 
-    client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
-    addedProcess, err := client.Submit(funcSpec, executorPrvKey)
-    if err != nil {
-        fmt.Println(err)
-        return
-    }
+	client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
+	addedProcess, err := client.Submit(funcSpec, executorPrvKey)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
-    fmt.Println("Submitted a new process to the Colonies server with Id <" + addedProcess.ID + ">")
+	fmt.Println("Submitted a new process to the Colonies server with Id <" + addedProcess.ID + ">")
 }
 ```
 
 
-## 6. Fibonacci Solver executor code (examples/solver.go) 
+## 6. Fibonacci Solver executor code (examples/solver/solver.go) 
 ```go
 func main() {
-    colonyID := os.Getenv("COLONIES_COLONY_ID")
-    executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
-    coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
-    coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
-    coloniesPort, err := strconv.Atoi(coloniesPortStr)
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(-1)
-    }
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
+	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
+	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
+	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
+	coloniesPort, err := strconv.Atoi(coloniesPortStr)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 
-    // Ask the Colonies server to assign a process to this executor 
-    client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
-    assignedProcess, err := client.Assign(colonyID, 100, executorPrvKey) // Max wait 100 seconds for assignment request
-    if err != nil {
-        fmt.Println(err)
-        return
-    }
+	// Ask the Colonies server to assign a process to this executor
+	client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
+	assignedProcess, err := client.Assign(colonyName, 100, "", "", executorPrvKey) // Max wait 100 seconds for assignment request
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
-    // Parse env attribute and calculate the given Fibonacci number
-    for _, attribute := range assignedProcess.Attributes {
-        if attribute.Key == "fibonacciNum" {
-            fmt.Println("We were assigned process " + assignedProcess.ID)
-            fmt.Println("Calculating Fibonacci serie for " + attribute.Value)
-            nr, _ := strconv.Atoi(attribute.Value)
-            fibonacci := fib.FibonacciBig(uint(nr))
-            fmt.Println("Result: The last number in the Fibonacci serie " + attribute.Value + " is " + fibonacci.String())
+	// Parse env attribute and calculate the given Fibonacci number
+	for _, attribute := range assignedProcess.Attributes {
+		if attribute.Key == "fibonacciNum" {
+			fmt.Println("We were assigned process " + assignedProcess.ID)
+			fmt.Println("Calculating Fibonacci serie for " + attribute.Value)
+			nr, _ := strconv.Atoi(attribute.Value)
+			fibonacci := fib.FibonacciBig(uint(nr))
+			fmt.Println("Result: The last number in the Fibonacci serie " + attribute.Value + " is " + fibonacci.String())
 
-            attribute := core.CreateAttribute(assignedProcess.ID, colonyID, "", core.OUT, "result", fibonacci.String())
-            client.AddAttribute(attribute, executorPrvKey)
+			attribute := core.CreateAttribute(assignedProcess.ID, colonyName, "", core.OUT, "result", fibonacci.String())
+			client.AddAttribute(attribute, executorPrvKey)
 
-            // Close the process as successful
-            client.Close(assignedProcess.ID, executorPrvKey)
-            return
-        }
-    }
+			// Close the process as successful
+			client.Close(assignedProcess.ID, executorPrvKey)
+			return
+		}
+	}
 
-    // Close the process as failed
-    client.Fail(assignedProcess.ID, "invalid args", executorPrvKey)
+	// Close the process as failed
+	client.Fail(assignedProcess.ID, []string{"invalid arg"}, executorPrvKey)
 }
 ```
 
@@ -168,4 +168,4 @@ Attributes:
 +------------------------------------------------------------------+--------------+-------+------+
 ```
 
-See examples/generate_sub.go and examples/solver_pub.go for an event-driven version of the generator and executor.
+See examples/generate_sub/generate_sub.go and examples/solver_pub/solver_pub.go for an event-driven version of the generator and executor.

--- a/examples/fibonacci/generator/generator.go
+++ b/examples/fibonacci/generator/generator.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	colonyID := os.Getenv("COLONIES_COLONY_ID")
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
 	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
 	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
 	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	funcSpec := core.CreateEmptyFunctionSpec()
-	funcSpec.Conditions.ColonyName = colonyID
+	funcSpec.Conditions.ColonyName = colonyName
 	funcSpec.Conditions.ExecutorType = os.Getenv("COLONIES_EXECUTOR_TYPE")
 	funcSpec.Env["fibonacciNum"] = os.Args[1]
 

--- a/examples/fibonacci/generator_sub/generator_sub.go
+++ b/examples/fibonacci/generator_sub/generator_sub.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	colonyID := os.Getenv("COLONIES_COLONY_ID")
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
 	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
 	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
 	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
@@ -19,10 +19,11 @@ func main() {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+	executorType := os.Getenv("COLONIES_EXECUTOR_TYPE")
 
 	funcSpec := core.CreateEmptyFunctionSpec()
-	funcSpec.Conditions.ColonyName = colonyID
-	funcSpec.Conditions.ExecutorType = os.Getenv("COLONIES_EXECUTOR_TYPE")
+	funcSpec.Conditions.ColonyName = colonyName
+	funcSpec.Conditions.ExecutorType = executorType
 	funcSpec.Env["fibonacciNum"] = os.Args[1]
 
 	client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
@@ -34,9 +35,9 @@ func main() {
 	fmt.Println("Submitted a new process to the Colonies server with Id <" + addedProcess.ID + ">")
 	fmt.Println("Waiting for process to be computed ...")
 
-	fmt.Println(os.Getenv("COLONIES_EXECUTOR_TYPE"))
+	fmt.Println(executorType)
 
-	subscription, _ := client.SubscribeProcess(addedProcess.ID, os.Getenv("COLONIES_EXECUTOR_TYPE"), core.SUCCESS, 100, executorPrvKey)
+	subscription, _ := client.SubscribeProcess(colonyName, addedProcess.ID, executorType, core.SUCCESS, 100, executorPrvKey)
 	process := <-subscription.ProcessChan
 
 	for _, attribute := range process.Attributes {

--- a/examples/fibonacci/solver/solver.go
+++ b/examples/fibonacci/solver/solver.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	colonyID := os.Getenv("COLONIES_COLONY_ID")
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
 	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
 	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
 	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
@@ -24,7 +24,7 @@ func main() {
 
 	// Ask the Colonies server to assign a process to this executor
 	client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
-	assignedProcess, err := client.Assign(colonyID, 100, executorPrvKey) // Max wait 100 seconds for assignment request
+	assignedProcess, err := client.Assign(colonyName, 100, "", "", executorPrvKey) // Max wait 100 seconds for assignment request
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -39,7 +39,7 @@ func main() {
 			fibonacci := fib.FibonacciBig(uint(nr))
 			fmt.Println("Result: The last number in the Fibonacci serie " + attribute.Value + " is " + fibonacci.String())
 
-			attribute := core.CreateAttribute(assignedProcess.ID, colonyID, "", core.OUT, "result", fibonacci.String())
+			attribute := core.CreateAttribute(assignedProcess.ID, colonyName, "", core.OUT, "result", fibonacci.String())
 			client.AddAttribute(attribute, executorPrvKey)
 
 			// Close the process as successful
@@ -49,5 +49,5 @@ func main() {
 	}
 
 	// Close the process as failed
-	client.Fail(assignedProcess.ID, "invalid arg", executorPrvKey)
+	client.Fail(assignedProcess.ID, []string{"invalid arg"}, executorPrvKey)
 }

--- a/examples/fibonacci/solver_sub/solver_sub.go
+++ b/examples/fibonacci/solver_sub/solver_sub.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	colonyID := os.Getenv("COLONIES_COLONY_ID")
+	colonyName := os.Getenv("COLONIES_COLONY_NAME")
 	executorPrvKey := os.Getenv("COLONIES_EXECUTOR_PRVKEY")
 	coloniesHost := os.Getenv("COLONIES_SERVER_HOST")
 	coloniesPortStr := os.Getenv("COLONIES_SERVER_PORT")
@@ -24,7 +24,7 @@ func main() {
 	client := client.CreateColoniesClient(coloniesHost, coloniesPort, true, false)
 
 	// Subscribe for new processes
-	subscription, err := client.SubscribeProcesses("cli", core.WAITING, 100, executorPrvKey)
+	subscription, err := client.SubscribeProcesses(colonyName, "cli", core.WAITING, 100, executorPrvKey)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -35,7 +35,7 @@ func main() {
 		for {
 			select {
 			case <-subscription.ProcessChan:
-				assignedProcess, err := client.Assign(colonyID, -1, executorPrvKey)
+				assignedProcess, err := client.Assign(colonyName, -1, "", "", executorPrvKey)
 				if err != nil {
 					fmt.Println(err)
 					continue
@@ -51,7 +51,7 @@ func main() {
 						fmt.Println("We were assigned process " + assignedProcess.ID)
 						fmt.Println("Result: The last number in the Fibonacci serie " + attribute.Value + " is " + fibonacci.String())
 
-						attribute := core.CreateAttribute(assignedProcess.ID, colonyID, "", core.OUT, "result", fibonacci.String())
+						attribute := core.CreateAttribute(assignedProcess.ID, colonyName, "", core.OUT, "result", fibonacci.String())
 						client.AddAttribute(attribute, executorPrvKey)
 
 						// Close the process as Successful


### PR DESCRIPTION
Updated the fibonacci examples to be compatible with the new API.
Also moved them to separate directories so that they are easier to run and make the IDE stop pestering me about redeclaration of main.

Finally, I noticed that the libcfslib.so was not present in .gitignore which I assumed it should be so I removed the file and ignored it.