### PR TITLE
Fix empty values for getgeneratorsmsg

### DIFF
--- a/pkg/server/generator_handlers.go
+++ b/pkg/server/generator_handlers.go
@@ -176,6 +176,14 @@ func (server *ColoniesServer) handleGetGeneratorsHTTPRequest(c *gin.Context, rec
 		return
 	}
 
+	for _, generator := range generators {
+		generator.CheckerPeriod = server.controller.getGeneratorPeriod()
+		queueSize, err := server.db.CountGeneratorArgs(generator.ID)
+		if server.handleHTTPError(c, err, http.StatusInternalServerError) {
+			return
+		}
+		generator.QueueSize = queueSize
+	}
 	jsonString, err = core.ConvertGeneratorArrayToJSON(generators)
 	if server.handleHTTPError(c, err, http.StatusInternalServerError) {
 		return


### PR DESCRIPTION
The RPC response for getgeneratorsmsg always returns empty values for queuesize and checkerperiod.

<details><summary>Example response for getgeneratormsg</summary>
<p>

"payload":"{
    "generatorid": "a0b7c0fdbe2ca061da7af4d833a51377ebf47fd51b4b2e19e8b7ab01f93f845f",
    "initiatorid": "3fc05cf3df4b494e95d6a3d297a34f19938f7daa7422ab0d4f794454133341ac",
    "initiatorname": "myexecutor",
    "colonyname": "dev",
    "name": "testgenerator",
    "workflowspec": {
      "colonyname": "dev",
      "functionspecs": [...]
    },
    "trigger": 12,
    "timeout": -1,
    "firstpack": "2025-09-08T12:50:30.621871+02:00",
    "lastrun": "0001-01-01T00:53:28+00:53",
    **"queuesize": 3,**
    **"checkerperiod": 1000**
  }"

</p>
</details> 

<details><summary>Example response for getgeneratorsmsg</summary>
<p>

"payload":"[{
    "generatorid": "a0b7c0fdbe2ca061da7af4d833a51377ebf47fd51b4b2e19e8b7ab01f93f845f",
    "initiatorid": "3fc05cf3df4b494e95d6a3d297a34f19938f7daa7422ab0d4f794454133341ac",
    "initiatorname": "myexecutor",
    "colonyname": "dev",
    "name": "testgenerator",
    "workflowspec": {
      "colonyname": "dev",
      "functionspecs": [...]
    },
    "trigger": 12,
    "timeout": -1,
    "firstpack": "2025-09-08T12:50:30.621871+02:00",
    "lastrun": "0001-01-01T00:53:28+00:53",
    **"queuesize": 0,**
    **"checkerperiod": 0**
  }]"

</p>
</details> 

For testing:

- Start dev server
- Add one or more generators
- Pack generators at least one time
- Check diff in response payload for getgeneratorsmsg compared to getgeneratormsg

This change has not been tested if there is a HTTP error in the middle of the for loop.